### PR TITLE
Platta CI/CD configuration (Azure Pipelines) (#172)

### DIFF
--- a/azure-pipelines-devtest.yml
+++ b/azure-pipelines-devtest.yml
@@ -1,0 +1,48 @@
+# Continuous integration (CI) triggers cause a pipeline to run whenever you push 
+# an update to the specified branches or you push specified tags.
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    exclude:
+    - README.md
+
+# Pull request (PR) triggers cause a pipeline to run whenever a pull request is 
+# opened with one of the specified target branches, or when updates are made to 
+# such a pull request.
+#
+# GitHub creates a new ref when a pull request is created. The ref points to a 
+# merge commit, which is the merged code between the source and target branches 
+# of the pull request.
+#
+# Opt out of pull request validation 
+pr: none
+
+# By default, use self-hosted agents
+pool: Default
+
+# Image tag name for Fuse projects
+#parameters:
+#- name: imagetag
+#  displayName: Image tag to be built and/or deployed
+#  type: string
+#  default: latest
+
+resources:
+  repositories:
+  # Azure DevOps repository
+  - repository: puistotalkoot-pipelines
+    type: git
+    # Azure DevOps project/repository
+    name: puistotalkoot/puistotalkoot-pipelines
+
+extends:
+  # Filename in Azure DevOps Repository (note possible -ui or -api)
+  # Django example: azure-pipelines-PROJECTNAME-api-master.yml
+  # Drupal example: azure-pipelines-drupal-master.yml
+  # template: azure-pipelines-PROJECTNAME-devtest.yml@PROJECTNAME-pipelines
+  template: azure-pipelines-puistotalkoot-ui-devtest.yml@puistotalkoot-pipelines
+  # Image tag name for Fuse projects
+  #parameters:
+    #imagetag: ${{ parameters.imagetag }}

--- a/azure-pipelines-stageprod.yml
+++ b/azure-pipelines-stageprod.yml
@@ -1,0 +1,49 @@
+# Continuous integration (CI) triggers cause a pipeline to run whenever you push 
+# an update to the specified branches or you push specified tags.
+trigger:
+  branches:
+    include:
+    - master
+#    - release/*
+#    - refs/tags/*
+  paths:
+    exclude:
+    - README.md
+
+# Pull request (PR) triggers cause a pipeline to run whenever a pull request is 
+# opened with one of the specified target branches, or when updates are made to 
+# such a pull request.
+#
+# GitHub creates a new ref when a pull request is created. The ref points to a 
+# merge commit, which is the merged code between the source and target branches 
+# of the pull request.
+#
+# Opt out of pull request validation 
+pr: none
+
+# By default, use self-hosted agents
+pool: Default
+
+# Image tag name for Fuse projects
+#parameters:
+#- name: imagetag
+#  displayName: Image tag to be built and/or deployed
+#  type: string
+#  default: latest
+
+resources:
+  repositories:
+  # Azure DevOps repository
+  - repository: puistotalkoot-pipelines
+    type: git
+    # Azure DevOps project/repository
+    name: puistotalkoot/puistotalkoot-pipelines
+
+extends:
+  # Filename in Azure DevOps Repository (note possible -ui or -api)
+  # Django example: azure-pipelines-PROJECTNAME-api-release.yml
+  # Drupal example: azure-pipelines-drupal-release.yml
+  # template: azure-pipelines-PROJECTNAME-stageprod.yml@PROJECTNAME-pipelines
+  template: azure-pipelines-puistotalkoot-ui-stageprod.yml@puistotalkoot-pipelines
+  #parameters:
+    #imagetag: ${{ parameters.imagetag }}


### PR DESCRIPTION
Add necessary stub files for Azure Pipelines as used on Platta.
This is not a release, but needed for CI/CD of the production branch to work.