### PR TITLE
Changes needed to run in Openshift

### DIFF
--- a/.prod/nginx.conf
+++ b/.prod/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen       80;
+    listen       8080;
     server_name  localhost;
 
     root /usr/share/nginx/html;

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 # Nginx wants to initialize the cache dirs even if cache is not used
 RUN chgrp -Rv 0 /var/cache/nginx && chmod -Rv g+w /var/cache/nginx && chmod -v g+w /var/run
 
-EXPOSE 80
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,8 @@ COPY --from=react-builder --chown=nginx:nginx /app/build /usr/share/nginx/html
 
 COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
+# Nginx wants to initialize the cache dirs even if cache is not used
+# Allow doing this when running as group 0 in Openshift
+RUN chgrp -Rv 0 /var/cache/nginx && chmod -Rv g+w /var/cache/nginx
+
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,9 @@ COPY --from=react-builder --chown=nginx:nginx /app/build /usr/share/nginx/html
 
 COPY .prod/nginx.conf /etc/nginx/conf.d/default.conf
 
+# Permissions needed for nginx to initialize the cache dirs & write
+# out the pid file when running under arbitrary uid and group 0.
 # Nginx wants to initialize the cache dirs even if cache is not used
-# Allow doing this when running as group 0 in Openshift
-RUN chgrp -Rv 0 /var/cache/nginx && chmod -Rv g+w /var/cache/nginx
+RUN chgrp -Rv 0 /var/cache/nginx && chmod -Rv g+w /var/cache/nginx && chmod -v g+w /var/run
 
 EXPOSE 80


### PR DESCRIPTION
Openshift is stricter than some other Kubernetes distributions:

* Listen on port 8080, instead of 80
* Allow group 0 as used under Openshift to initialize cache dir & write the pidfile