### PR TITLE
Fix next page button

### DIFF
--- a/src/components/pages/events/ManageEventsPage.tsx
+++ b/src/components/pages/events/ManageEventsPage.tsx
@@ -290,6 +290,7 @@ const ManageEventsPage = () => {
           <ButtonControls>
             {Object.keys(nextParams).length > 0 && (
               <NextPageButton
+                data-testid="next-page"
                 translate="site.page.manage_events.next_events"
                 color="info"
                 onClick={() => handleNextEvents()}

--- a/src/components/pages/events/__tests__/ManageEventsPage.test.tsx
+++ b/src/components/pages/events/__tests__/ManageEventsPage.test.tsx
@@ -7,6 +7,10 @@ import * as useAuthMock from '../../../../hooks/useAuth';
 import renderWithProviders from '../../../../test-utils/renderWithProviders';
 import { mockUserCreator } from '../../../../test-utils/mocks/user';
 import ManageEventsPage from '../ManageEventsPage';
+import { RootState } from 'store/configureStore';
+import eventService from 'store/services/eventService';
+import { Event } from '../../../../store/types';
+import { Map } from 'immutable';
 
 const mockUser = mockUserCreator();
 
@@ -35,9 +39,7 @@ const initialState = {
   },
   event: {
     count: 1,
-    next: {
-      limit: 10,
-    },
+    next: {},
     events: {
       '1': {
         id: 1,
@@ -76,7 +78,7 @@ const initialState = {
   },
 };
 
-const renderComponent = () => {
+const renderComponent = (preloadedState?: Partial<RootState>) => {
   jest.spyOn(useAuthMock, 'default').mockImplementation(() => ({
     authenticated: true,
     user: mockUser,
@@ -89,7 +91,7 @@ const renderComponent = () => {
     <BrowserRouter>
       <ManageEventsPage />
     </BrowserRouter>,
-    { preloadedState: initialState },
+    { preloadedState: preloadedState || initialState },
   );
 };
 
@@ -98,6 +100,97 @@ describe('<ManageEventsPage />', () => {
     renderComponent();
 
     await waitFor(() => expect(screen.getByRole('table').children[1].children).toHaveLength(1));
+    await waitFor(() => expect(screen.queryByTestId('next-page')).not.toBeInTheDocument());
+  });
+
+  it('should show the next page button when there are more events', async () => {
+    const state = {
+      ...initialState,
+      event: {
+        ...initialState.event,
+        count: 2,
+        next: {
+          limit: 1,
+          offset: 1,
+        },
+      },
+    };
+
+    renderComponent(state);
+
+    await waitFor(() => expect(screen.getByTestId('next-page')).toBeInTheDocument());
+  });
+
+  it('should fetch next page of events', async () => {
+    const event = {
+      id: 2,
+      state: 'waiting_for_approval',
+      created_at: '2024-12-04T06:17:08.196Z',
+      modified_at: '2024-12-04T06:17:08.196Z',
+      name: 'Puistotalkoot',
+      description: 'Puistotalkoot',
+      start_time: '2025-01-15T07:00:00.000Z',
+      end_time: '2025-02-16T07:00:00.000Z',
+      location: {
+        type: 'Point',
+        coordinates: [24.93931620883691, 60.18799324237526],
+      },
+      organizer_first_name: 'Etunimi',
+      organizer_last_name: 'Sukunimi',
+      organizer_email: 'sahko@posti.fi',
+      organizer_phone: '1234567',
+      estimated_attendee_count: 1,
+      targets: '1',
+      maintenance_location: 'Tivolikuja 1',
+      additional_information: '1',
+      small_trash_bag_count: 1,
+      large_trash_bag_count: 1,
+      trash_picker_count: 1,
+      equipment_information: '',
+      contract_zone: 1,
+    };
+
+    jest.spyOn(eventService, 'getEvents').mockResolvedValue({
+      data: {
+        count: 2,
+        next: null,
+        previous: null,
+        results: [event],
+      },
+      events: Map<string, Event>({
+        '2': {
+          ...event,
+          start_time: new Date(`${event.start_time}`),
+          end_time: new Date(`${event.end_time}`),
+          created_at: new Date(`${event.created_at}`),
+          modified_at: new Date(`${event.modified_at}`),
+        },
+      }),
+    });
+
+    const state = {
+      ...initialState,
+      event: {
+        ...initialState.event,
+        count: 2,
+        next: {
+          limit: 1,
+          offset: 1,
+        },
+      },
+    };
+
+    renderComponent(state);
+
+    const nextPageButton = await screen.findByTestId('next-page');
+
+    const user = userEvent.setup();
+
+    await user.click(nextPageButton);
+
+    await waitFor(() => expect(screen.getByRole('table').children[1].children).toHaveLength(2));
+
+    await waitFor(() => expect(screen.queryByTestId('next-page')).not.toBeInTheDocument());
   });
 
   it('should remove event', async () => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,3 +9,5 @@ export const SUPPORT_LANGUAGES = {
 export const DEFAULT_LANGUAGE = 'fi';
 
 export const REPORTS_START_YEAR = 2020;
+
+export const EVENTS_PAGE_SIZE = 10;

--- a/src/store/reducers/event.ts
+++ b/src/store/reducers/event.ts
@@ -7,7 +7,7 @@ import { EVENTS_PAGE_SIZE } from '../../constants';
 
 interface EventState {
   count: number;
-  next: { limit: number };
+  next: { limit?: number; offset?: number };
   events: Record<string, Event>;
   filterByContractZone: number | null;
   ordering: Ordering;
@@ -121,18 +121,19 @@ const eventSlice = createSlice({
     getEventsFulfilled: (
       state,
       action: PayloadAction<{
-        data: { next: { limit: number }; count: number };
+        data: { next: { limit?: number; offset?: number }; count: number };
         events: Record<string, Event>;
       }>,
     ) => {
       const next = urlParse(JSON.stringify(action.payload.data.next), true).query;
       state.count = action.payload.data.count;
       state.next = {
-        limit: parseInt(next.limit as string, 10) || 10,
+        ...(next.limit && { limit: parseInt(next.limit, 10) }),
+        ...(next.offset && { offset: parseInt(next.offset, 10) }),
       };
       state.ordering = ordering;
 
-      state.events = action.payload.events;
+      state.events = { ...state.events, ...action.payload.events };
     },
     submitEventFulfilled: (state, action: PayloadAction<Event>) => {
       state.submittedEvent = action.payload;

--- a/src/store/reducers/event.ts
+++ b/src/store/reducers/event.ts
@@ -3,6 +3,7 @@ import urlParse from 'url-parse';
 import eventService from '../services/eventService';
 import ordering, { Ordering } from '../../utils/entities/ordering';
 import { Event } from '../types';
+import { EVENTS_PAGE_SIZE } from '../../constants';
 
 interface EventState {
   count: number;
@@ -15,7 +16,7 @@ interface EventState {
 
 const initialState: EventState = {
   count: 0,
-  next: { limit: 10 },
+  next: { limit: EVENTS_PAGE_SIZE },
   events: {},
   filterByContractZone: null,
   ordering,


### PR DESCRIPTION
This was hard-coded to get the first page only. Now it will correctly get the next page.

This also fixes the visibility of the next page button. It will now be hidden if there are no more pages to get.

Refs: PS-176