### PR TITLE
fix: event ordering resetting on each loaded event slice

### DIFF
--- a/src/store/reducers/event.ts
+++ b/src/store/reducers/event.ts
@@ -133,7 +133,10 @@ const eventSlice = createSlice({
         ...(next.limit && { limit: parseInt(next.limit, 10) }),
         ...(next.offset && { offset: parseInt(next.offset, 10) }),
       };
-      state.ordering = ordering;
+
+      // commented out to avoid reordering the events because it's done in the frontend-side currently
+      // ordering would be null
+      // state.ordering = ordering;
 
       state.events = { ...state.events, ...action.payload.events };
     },


### PR DESCRIPTION
Ordering would become null on every additional loading of more events since no `ordering` data is available to set.

Refs: PS-181