### PR TITLE
feat: force a scrollbar to be present if there is horizontal overflow

### DIFF
--- a/src/components/common/Table.tsx
+++ b/src/components/common/Table.tsx
@@ -69,8 +69,19 @@ const StyledFirstTd = styled.td<{ highlighted?: boolean }>`
 `;
 
 const StyledTableWrapper = styled.div`
-  overflow: auto;
+  overflow-x: scroll;
   max-width: calc(100vw - 2rem);
+
+  ::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.5);
+    -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+  }
 `;
 
 const StyledTable = styled.table<{ firstColumn?: boolean }>`


### PR DESCRIPTION
add CSS to force scroll bar to be visible all the time. Does not solve problem for Firefox. Div was already scrollable but since some mouses do not have support for horizontal scrolling, it seemed like a bug.